### PR TITLE
fix(SNP-926): ScrollController initializations moved form constructor

### DIFF
--- a/lib/src/cupertino_swipe_refresh.dart
+++ b/lib/src/cupertino_swipe_refresh.dart
@@ -83,7 +83,8 @@ class CupertinoSwipeRefresh extends SwipeRefreshBase {
   SwipeRefreshBaseState createState() => _CupertinoSwipeRefreshState();
 }
 
-class _CupertinoSwipeRefreshState extends SwipeRefreshBaseState<CupertinoSwipeRefresh> {
+class _CupertinoSwipeRefreshState
+    extends SwipeRefreshBaseState<CupertinoSwipeRefresh> {
   late final ScrollController _scrollController;
 
   @override
@@ -101,8 +102,8 @@ class _CupertinoSwipeRefreshState extends SwipeRefreshBaseState<CupertinoSwipeRe
     return CustomScrollView(
       shrinkWrap: widget.shrinkWrap,
       controller: _scrollController,
-      keyboardDismissBehavior:
-          widget.keyboardDismissBehavior ?? ScrollViewKeyboardDismissBehavior.onDrag,
+      keyboardDismissBehavior: widget.keyboardDismissBehavior ??
+          ScrollViewKeyboardDismissBehavior.onDrag,
       physics: widget.physics == null
           ? const BouncingScrollPhysics(
               parent: AlwaysScrollableScrollPhysics(),

--- a/lib/src/cupertino_swipe_refresh.dart
+++ b/lib/src/cupertino_swipe_refresh.dart
@@ -53,18 +53,18 @@ class CupertinoSwipeRefresh extends SwipeRefreshBase {
   const CupertinoSwipeRefresh({
     required Stream<SwipeRefreshState> stateStream,
     required VoidCallback onRefresh,
-    Key? key,
-    SliverChildDelegate? childrenDelegate,
+    this.refreshTriggerPullDistance = defaultRefreshTriggerPullDistance,
+    this.refreshIndicatorExtent = defaultRefreshIndicatorExtent,
+    this.indicatorBuilder = CupertinoSliverRefreshControl.buildRefreshIndicator,
     List<Widget>? children,
+    SliverChildDelegate? childrenDelegate,
     SwipeRefreshState? initState,
     EdgeInsets? padding,
     ScrollController? scrollController,
     bool shrinkWrap = false,
-    this.refreshTriggerPullDistance = defaultRefreshTriggerPullDistance,
-    this.refreshIndicatorExtent = defaultRefreshIndicatorExtent,
-    this.indicatorBuilder = CupertinoSliverRefreshControl.buildRefreshIndicator,
     ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior,
     ScrollPhysics? physics,
+    Key? key,
   }) : super(
           key: key,
           children: children,
@@ -72,27 +72,25 @@ class CupertinoSwipeRefresh extends SwipeRefreshBase {
           stateStream: stateStream,
           initState: initState,
           onRefresh: onRefresh,
-          padding: padding,
           scrollController: scrollController,
+          padding: padding,
           shrinkWrap: shrinkWrap,
           keyboardDismissBehavior: keyboardDismissBehavior,
           physics: physics,
         );
 
   @override
-  // ignore: no_logic_in_create_state
-  SwipeRefreshBaseState createState() => _CupertinoSwipeRefreshState(
-        scrollController,
-      );
+  SwipeRefreshBaseState createState() => _CupertinoSwipeRefreshState();
 }
 
-class _CupertinoSwipeRefreshState
-    extends SwipeRefreshBaseState<CupertinoSwipeRefresh> {
-  final ScrollController _scrollController;
+class _CupertinoSwipeRefreshState extends SwipeRefreshBaseState<CupertinoSwipeRefresh> {
+  late final ScrollController _scrollController;
 
-  _CupertinoSwipeRefreshState(
-    ScrollController? scrollController,
-  ) : _scrollController = scrollController ?? ScrollController();
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = widget.scrollController ?? ScrollController();
+  }
 
   @override
   Widget buildRefresher(
@@ -103,8 +101,8 @@ class _CupertinoSwipeRefreshState
     return CustomScrollView(
       shrinkWrap: widget.shrinkWrap,
       controller: _scrollController,
-      keyboardDismissBehavior: widget.keyboardDismissBehavior ??
-          ScrollViewKeyboardDismissBehavior.onDrag,
+      keyboardDismissBehavior:
+          widget.keyboardDismissBehavior ?? ScrollViewKeyboardDismissBehavior.onDrag,
       physics: widget.physics == null
           ? const BouncingScrollPhysics(
               parent: AlwaysScrollableScrollPhysics(),

--- a/lib/src/material_swipe_refresh.dart
+++ b/lib/src/material_swipe_refresh.dart
@@ -52,18 +52,18 @@ class MaterialSwipeRefresh extends SwipeRefreshBase {
   const MaterialSwipeRefresh({
     required Stream<SwipeRefreshState> stateStream,
     required VoidCallback onRefresh,
-    Key? key,
     this.indicatorColor,
     List<Widget>? children,
     SliverChildDelegate? childrenDelegate,
     SwipeRefreshState? initState,
     Color? backgroundColor,
-    ScrollController? scrollController,
     EdgeInsets? padding,
+    ScrollController? scrollController,
     bool shrinkWrap = false,
     ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior,
     ScrollPhysics? physics,
-  })  : backgroundColor = backgroundColor ?? const Color(0xFFFFFFFF),
+    Key? key,
+  })  : backgroundColor = backgroundColor ?? Colors.white,
         super(
           key: key,
           children: children,
@@ -79,11 +79,10 @@ class MaterialSwipeRefresh extends SwipeRefreshBase {
         );
 
   @override
-  _MaterialSwipeRefreshState createState() => _MaterialSwipeRefreshState();
+  SwipeRefreshBaseState createState() => _MaterialSwipeRefreshState();
 }
 
-class _MaterialSwipeRefreshState
-    extends SwipeRefreshBaseState<MaterialSwipeRefresh> {
+class _MaterialSwipeRefreshState extends SwipeRefreshBaseState<MaterialSwipeRefresh> {
   @override
   Widget buildRefresher(
     Key key,
@@ -101,8 +100,8 @@ class _MaterialSwipeRefreshState
               padding: widget.padding,
               controller: widget.scrollController ?? ScrollController(),
               physics: AlwaysScrollableScrollPhysics(parent: widget.physics),
-              keyboardDismissBehavior: widget.keyboardDismissBehavior ??
-                  ScrollViewKeyboardDismissBehavior.manual,
+              keyboardDismissBehavior:
+                  widget.keyboardDismissBehavior ?? ScrollViewKeyboardDismissBehavior.manual,
               children: children,
             )
           : ListView.custom(
@@ -110,8 +109,8 @@ class _MaterialSwipeRefreshState
               padding: widget.padding,
               childrenDelegate: widget.childrenDelegate!,
               controller: widget.scrollController ?? ScrollController(),
-              keyboardDismissBehavior: widget.keyboardDismissBehavior ??
-                  ScrollViewKeyboardDismissBehavior.manual,
+              keyboardDismissBehavior:
+                  widget.keyboardDismissBehavior ?? ScrollViewKeyboardDismissBehavior.manual,
               physics: AlwaysScrollableScrollPhysics(parent: widget.physics),
             ),
     );

--- a/lib/src/material_swipe_refresh.dart
+++ b/lib/src/material_swipe_refresh.dart
@@ -82,7 +82,8 @@ class MaterialSwipeRefresh extends SwipeRefreshBase {
   SwipeRefreshBaseState createState() => _MaterialSwipeRefreshState();
 }
 
-class _MaterialSwipeRefreshState extends SwipeRefreshBaseState<MaterialSwipeRefresh> {
+class _MaterialSwipeRefreshState
+    extends SwipeRefreshBaseState<MaterialSwipeRefresh> {
   @override
   Widget buildRefresher(
     Key key,
@@ -100,8 +101,8 @@ class _MaterialSwipeRefreshState extends SwipeRefreshBaseState<MaterialSwipeRefr
               padding: widget.padding,
               controller: widget.scrollController ?? ScrollController(),
               physics: AlwaysScrollableScrollPhysics(parent: widget.physics),
-              keyboardDismissBehavior:
-                  widget.keyboardDismissBehavior ?? ScrollViewKeyboardDismissBehavior.manual,
+              keyboardDismissBehavior: widget.keyboardDismissBehavior ??
+                  ScrollViewKeyboardDismissBehavior.manual,
               children: children,
             )
           : ListView.custom(
@@ -109,8 +110,8 @@ class _MaterialSwipeRefreshState extends SwipeRefreshBaseState<MaterialSwipeRefr
               padding: widget.padding,
               childrenDelegate: widget.childrenDelegate!,
               controller: widget.scrollController ?? ScrollController(),
-              keyboardDismissBehavior:
-                  widget.keyboardDismissBehavior ?? ScrollViewKeyboardDismissBehavior.manual,
+              keyboardDismissBehavior: widget.keyboardDismissBehavior ??
+                  ScrollViewKeyboardDismissBehavior.manual,
               physics: AlwaysScrollableScrollPhysics(parent: widget.physics),
             ),
     );

--- a/lib/src/swipe_refresh_base.dart
+++ b/lib/src/swipe_refresh_base.dart
@@ -52,8 +52,7 @@ abstract class SwipeRefreshBase extends StatefulWidget {
   SwipeRefreshBaseState createState();
 }
 
-abstract class SwipeRefreshBaseState<T extends SwipeRefreshBase>
-    extends State<T> {
+abstract class SwipeRefreshBaseState<T extends SwipeRefreshBase> extends State<T> {
   @protected
   final GlobalKey refreshKey = GlobalKey();
 
@@ -77,37 +76,6 @@ abstract class SwipeRefreshBaseState<T extends SwipeRefreshBase>
     _stateSubscription = widget.stateStream.listen(_updateState);
   }
 
-  @override
-  Widget build(BuildContext context) {
-    // ignore: avoid-returning-widgets
-    return buildRefresher(refreshKey, widget.children ?? [], _onRefresh);
-  }
-
-  @override
-  void dispose() {
-    _stateSubscription?.cancel();
-
-    super.dispose();
-  }
-
-  @protected
-  Widget buildRefresher(
-    Key key,
-    List<Widget> children,
-    Future<void> Function() onRefresh,
-  );
-
-  @protected
-  void onUpdateState(SwipeRefreshState state);
-
-  @protected
-  Future<void> _onRefresh() {
-    _updateState(SwipeRefreshState.loading);
-    widget.onRefresh();
-    completer = Completer<void>();
-    return completer!.future;
-  }
-
   void _updateState(SwipeRefreshState newState) {
     if (currentState != newState) {
       setState(
@@ -119,4 +87,34 @@ abstract class SwipeRefreshBaseState<T extends SwipeRefreshBase>
       );
     }
   }
+
+  @protected
+  Future<void> _onRefresh() {
+    _updateState(SwipeRefreshState.loading);
+    widget.onRefresh();
+    completer = Completer<void>();
+    return completer!.future;
+  }
+
+  @override
+  void dispose() {
+    _stateSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // ignore: avoid-returning-widgets
+    return buildRefresher(refreshKey, widget.children ?? [], _onRefresh);
+  }
+
+  @protected
+  Widget buildRefresher(
+    Key key,
+    List<Widget> children,
+    Future<void> Function() onRefresh,
+  );
+
+  @protected
+  void onUpdateState(SwipeRefreshState state);
 }

--- a/lib/src/swipe_refresh_base.dart
+++ b/lib/src/swipe_refresh_base.dart
@@ -52,7 +52,8 @@ abstract class SwipeRefreshBase extends StatefulWidget {
   SwipeRefreshBaseState createState();
 }
 
-abstract class SwipeRefreshBaseState<T extends SwipeRefreshBase> extends State<T> {
+abstract class SwipeRefreshBaseState<T extends SwipeRefreshBase>
+    extends State<T> {
   @protected
   final GlobalKey refreshKey = GlobalKey();
 


### PR DESCRIPTION
## Changes
ScrollController initialization moved from the _CupertinoSwipeRefreshState constructor.

## Issues
Resolve #4
